### PR TITLE
Fix/compiling errors

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -31,7 +31,7 @@
     "selfEmployedProgram": "Self-Employed Program",
     "HumanitarianANdCompassionate": "Humanitarian and Compassionate Program",
     "atlanticImmigrationProgram": "Atlantic Immigration Program",
-    "northenImmigrationProgram": "Northern Immigration Program - RNIP Program",
+    "northernImmigrationProgram": "Northern Immigration Program - RNIP Program",
     "services": "Services",
     "company": "Company",
     "sponsor": "Sponsor",

--- a/messages/es.json
+++ b/messages/es.json
@@ -31,7 +31,7 @@
     "selfEmployedProgram": "Programa para Trabajadores Autónomos",
     "HumanitarianANdCompassionate": "Programa Humanitario y Compasivo",
     "atlanticImmigrationProgram": "Programa de Inmigración Atlántica",
-    "northenImmigrationProgram": "Programa de Inmigración del Norte - Programa RNIP",
+    "northernImmigrationProgram": "Programa de Inmigración del Norte - Programa RNIP",
     "services": "Servicios",
     "company": "Empresa",
     "sponsor": "Patrocinador",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -270,7 +270,7 @@
     "discoverOptionsLabel2": "Permissão de trabalho aberta",
     "discoverOptionsLabel3": "Permissão de Trabalho de Pós-Graduação (PGWP)",
     "discoverOptionsLabel4": "Avaliação de Impacto no Mercado de Trabalho (LMIA)",
-    "discoverOptionsLabel5": "Permissão de trabalho aberta para cônjuge/parceiro de direito consuetudinário (SOWP)",
+    "discoverOptionsLabel5": "Permissão de trabalho aberta para cônjuge/parceiro (SOWP)",
     "navCard1Title": "Permissão de Trabalho/Extensões",
     "navCard1Description": "Os empregadores canadenses podem contratar trabalhadores estrangeiros temporários quando não for possível encontrar candidatos adequados entre os residentes canadenses (residentes permanentes ou cidadãos). Os empregadores que pretendam contratar trabalhadores estrangeiros devem solicitar um documento denominado Avaliação de Impacto no Mercado de Trabalho (LMIA) se cumprirem os critérios de elegibilidade. Um LMIA positivo demonstra a necessidade de um trabalhador estrangeiro para ocupar o cargo.",
     "navCard2Title": "Permissão de trabalho aberta",
@@ -279,7 +279,7 @@
     "navCard3Description": "Para indivíduos com experiência relevante em atividades culturais ou atléticas obterem residência permanente no Canadá. Este programa é ideal para aqueles que demonstraram capacidade de trabalhar por conta própria em áreas como música, escrita, artes visuais ou atletismo profissional. Ao contribuir com seus talentos únicos, os trabalhadores autônomos ajudam a enriquecer o cenário cultural e atlético do Canadá.",
     "navCard4Title": "Avaliação de Impacto no Mercado de Trabalho (LMIA)",
     "navCard4Description": "Para que trabalhadores estrangeiros qualificados e graduados internacionais construam uma nova vida em uma das vibrantes províncias atlânticas do Canadá: New Brunswick, Nova Escócia, Terra Nova e Labrador e Ilha do Príncipe Eduardo. Este programa facilita a fixação dos recém-chegados e contribui para o crescimento destas comunidades acolhedoras.",
-    "navCard5Title": "Permissão de trabalho aberta para cônjuge/parceiro de direito consuetudinário (SOWP)",
+    "navCard5Title": "Permissão de trabalho aberta para cônjuge/parceiro (SOWP)",
     "navCard5Description": "Cônjuge, companheiro ou companheiro conjugal que mora no Canadá e que está sendo patrocinado para residência permanente, acompanhando um filho dependente do requerente principal."
   },
   "Study": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -31,7 +31,7 @@
     "selfEmployedProgram": "Programa para Trabalhadores Autônomos",
     "HumanitarianANdCompassionate": "Programa Humanitário e Compadecido",
     "atlanticImmigrationProgram": "Programa de Imigração do Atlântico",
-    "northenImmigrationProgram": "Programa de Imigração do Norte - Programa RNIP",
+    "northernImmigrationProgram": "Programa de Imigração do Norte - Programa RNIP",
     "services": "Serviços",
     "company": "Empresa",
     "sponsor": "Patrocinador",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "react-dom": "^18",
         "react-hook-form": "^7.53.1",
         "react-icons": "^5.3.0",
-        "sharp": "^0.33.5",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8",
@@ -55,16 +54,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -248,367 +237,6 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2359,19 +1987,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2387,16 +2002,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2559,15 +2164,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/detect-node-es": {
@@ -3816,12 +3412,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -5452,6 +5042,7 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5503,45 +5094,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "node_modules/shebang-command": {
@@ -5644,15 +5196,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/source-map-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "^18",
         "react-hook-form": "^7.53.1",
         "react-icons": "^5.3.0",
+        "sharp": "^0.33.5",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8",
@@ -54,6 +55,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
+      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -237,6 +248,367 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1987,6 +2359,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2002,6 +2387,16 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2164,6 +2559,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node-es": {
@@ -3412,6 +3816,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -5042,7 +5452,6 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5094,6 +5503,45 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "node_modules/shebang-command": {
@@ -5196,6 +5644,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.53.1",
     "react-icons": "^5.3.0",
+    "sharp": "^0.33.5",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "react-dom": "^18",
     "react-hook-form": "^7.53.1",
     "react-icons": "^5.3.0",
-    "sharp": "^0.33.5",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8",

--- a/src/app/_footer/_components/Logo.tsx
+++ b/src/app/_footer/_components/Logo.tsx
@@ -1,18 +1,12 @@
-import logoWhite from '@/public/logoWhite.png'
-import Image from "next/legacy/image";
+import { ResponsiveImage } from "@/components/common/ResponsiveImage";
+import logoWhite from "@/public/logoWhite.png";
 
 export default function Logo() {
   return (
-    <div className="flex-shrink-0 mb-6 md:mb-0 flex items-center justify-center">
-      <Image
-        src={logoWhite}
-        alt="logo image"
-        quality={100}
-        width={200}
-        height={100}
-        priority
-        //   className="w-36 lg:w-56 lg:h-32"
-      />
-    </div>
+    <ResponsiveImage
+      alt="logo image"
+      src={logoWhite}
+      divClassName="flex-shrink-0 mb-6 md:mb-0 flex items-center justify-center w-[200px] h-[100px]"
+    />
   );
 }

--- a/src/app/_footer/_components/Logo.tsx
+++ b/src/app/_footer/_components/Logo.tsx
@@ -1,5 +1,5 @@
 import logoWhite from '@/public/logoWhite.png'
-import Image from 'next/image';
+import Image from "next/legacy/image";
 
 export default function Logo() {
   return (

--- a/src/app/_header/Header.tsx
+++ b/src/app/_header/Header.tsx
@@ -43,8 +43,8 @@ export default function Header() {
   const classNameForMobile = cn("flex lg:hidden");
 
   return (
-    <header className="px-6 py-2 bg-primary-white fixed z-50 top-0 w-full h-[102px]">
-      <div className="flex items-center justify-between">
+    <header className="px-6 py-2 bg-primary-white fixed z-50 top-0 w-full h-[72px]">
+      <div className="flex items-center justify-between h-full">
         <LogoButton />
         {/* For Desktop */}
         <NavigationMenuForDesktop

--- a/src/app/_header/Header.tsx
+++ b/src/app/_header/Header.tsx
@@ -43,7 +43,7 @@ export default function Header() {
   const classNameForMobile = cn("flex lg:hidden");
 
   return (
-    <header className="px-6 py-2 bg-primary-white fixed z-50 top-0 w-full h-[72px]">
+    <header className="px-6 py-2 bg-primary-white fixed z-50 top-0 w-full h-[102px]">
       <div className="flex items-center justify-between">
         <LogoButton />
         {/* For Desktop */}

--- a/src/app/_header/Header.tsx
+++ b/src/app/_header/Header.tsx
@@ -1,10 +1,10 @@
+import LanguageSwitcher from "@/components/common/LocaleSwitcher";
+import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
 import { BookFreeConsultation } from "../../components/common/BookFreeConsultation";
+import HamburgerMenu from "./_components/HamburgerMenu";
 import LogoButton from "./_components/LogoButton";
 import NavigationMenuForDesktop from "./_components/NavigationMenuForDesktop";
-import HamburgerMenu from "./_components/HamburgerMenu";
-import { cn } from "@/lib/utils";
-import LanguageSwitcher from "@/components/common/LocaleSwitcher";
 
 export type HeaderComponent = {
   title: string;
@@ -29,7 +29,7 @@ export default function Header() {
       href: `${urlPrefix}/humanitarian`,
     },
     { title: t("atlanticImmigrationProgram"), href: `${urlPrefix}/atlantic` },
-    { title: t("northenImmigrationProgram"), href: `${urlPrefix}/rnip` },
+    { title: t("northernImmigrationProgram"), href: `${urlPrefix}/rnip` },
   ];
 
   const workComponents: HeaderComponent[] = [

--- a/src/app/_header/_components/HamburgerMenu.tsx
+++ b/src/app/_header/_components/HamburgerMenu.tsx
@@ -1,39 +1,47 @@
 import {
-    Sheet,
-    SheetClose,
-    SheetContent,
-    SheetFooter,
-    SheetTrigger,
-} from "@/components/ui/SheetForHeader"
-import { contactData } from '@/data/ContactData'
-import { Menu } from 'lucide-react'
-import ContactMenu from '../../../components/common/ContactMenu'
-import { HeaderComponent } from '../Header'
-import NavigationMenuForMobile from './NavigationMenuForMobile'
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/SheetForHeader";
+import { contactData } from "@/data/ContactData";
+import { Menu } from "lucide-react";
+import ContactMenu from "../../../components/common/ContactMenu";
+import { HeaderComponent } from "../Header";
+import NavigationMenuForMobile from "./NavigationMenuForMobile";
 
 type Props = {
-    className: string | undefined
-    immigrateComponents: HeaderComponent[]
-    workComponents: HeaderComponent[]
-}
+  className: string | undefined;
+  immigrateComponents: HeaderComponent[];
+  workComponents: HeaderComponent[];
+};
 
-export default function HamburgerMenu({className, immigrateComponents, workComponents}: Props) {
-    return (
-        <Sheet>
-            <SheetTrigger asChild>
-                <Menu className={`"h-10 w-10" ${className}`} />
-            </SheetTrigger>
-            <SheetContent>
-                <NavigationMenuForMobile 
-                    immigrateComponents={immigrateComponents}
-                    workComponents={workComponents}
-                />
-                <SheetFooter>
-                    <SheetClose asChild>
-                        <ContactMenu className="fixed bottom-10" components={contactData}/>
-                    </SheetClose>
-                </SheetFooter>
-            </SheetContent>
-        </Sheet>
-    )
+export default function HamburgerMenu({
+  className,
+  immigrateComponents,
+  workComponents,
+}: Props) {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Menu className={`"h-10 w-10" ${className}`} />
+      </SheetTrigger>
+      <SheetContent>
+        <SheetTitle />
+        <SheetDescription />
+        <NavigationMenuForMobile
+          immigrateComponents={immigrateComponents}
+          workComponents={workComponents}
+        />
+        <SheetFooter>
+          <SheetClose asChild>
+            <ContactMenu className="fixed bottom-10" components={contactData} />
+          </SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
 }

--- a/src/app/_header/_components/LogoButton.tsx
+++ b/src/app/_header/_components/LogoButton.tsx
@@ -1,19 +1,11 @@
-import Image from "next/legacy/image";
+import { ResponsiveImage } from "@/components/common/ResponsiveImage";
 import Link from "next/link";
 import logo from "../../../public/logo.png";
 
 export default function LogoButton() {
   return (
-    <Link href="/">
-      <Image
-        src={logo}
-        alt="logo image"
-        quality={100}
-        width={200}
-        height={100}
-        priority
-        className="w-32 lg:w-32"
-      />
+    <Link href="/" className="h-full">
+      <ResponsiveImage src={logo} alt="logo image" divClassName="w-32 h-full" />
     </Link>
   );
 }

--- a/src/app/_header/_components/LogoButton.tsx
+++ b/src/app/_header/_components/LogoButton.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import Image from "next/legacy/image";
 import Link from "next/link";
 import logo from "../../../public/logo.png";
 

--- a/src/app/_header/_components/NavigationMenuForDesktop.tsx
+++ b/src/app/_header/_components/NavigationMenuForDesktop.tsx
@@ -1,77 +1,80 @@
 import {
-    NavigationMenu,
-    NavigationMenuContent,
-    NavigationMenuItem,
-    NavigationMenuLink,
-    NavigationMenuList,
-    NavigationMenuTrigger,
-} from "@/components/ui/HeaderNavigationMenu"
-import { useTranslations } from "next-intl"
-import { HeaderComponent } from "../Header"
-import SubMenu from "./SubMenu"
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+} from "@/components/ui/HeaderNavigationMenu";
+import { useTranslations } from "next-intl";
+import { HeaderComponent } from "../Header";
+import SubMenu from "./SubMenu";
 
 type Props = {
-    className: string | undefined
-    immigrateComponents: HeaderComponent[]
-    workComponents: HeaderComponent[] // It's not used for now, but I kept it for future use
-}
+  className: string | undefined;
+  immigrateComponents: HeaderComponent[];
+  workComponents: HeaderComponent[]; // It's not used for now, but I kept it for future use
+};
 
-export default function NavigationMenuForDesktop({className, immigrateComponents, workComponents}: Props) {
-    const t = useTranslations("NavigationMenu")
+export default function NavigationMenuForDesktop({
+  className,
+  immigrateComponents,
+}: Props) {
+  const t = useTranslations("NavigationMenu");
 
-    return (
-        <NavigationMenu className={className}>
-            <NavigationMenuList className='space-x-9'>
-                {/* Immigrate */}
-                <NavigationMenuItem>
-                    <NavigationMenuTrigger>{t("immigrate")}</NavigationMenuTrigger>
-                    <NavigationMenuContent>
-                        <SubMenu components={immigrateComponents}/>
-                    </NavigationMenuContent>
-                </NavigationMenuItem>
-                {/* Work */}
-                {/* <NavigationMenuItem>
+  return (
+    <NavigationMenu className={className}>
+      <NavigationMenuList className="space-x-9">
+        {/* Immigrate */}
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>{t("immigrate")}</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <SubMenu components={immigrateComponents} />
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        {/* Work */}
+        {/* <NavigationMenuItem>
                     <NavigationMenuTrigger>{t("work")}</NavigationMenuTrigger>
                     <NavigationMenuContent>
                         <SubMenu components={workComponents}/>
                     </NavigationMenuContent>
                 </NavigationMenuItem> */}
-                <NavigationMenuItem>
-                    <NavigationMenuLink href="/work"  className="text-menu">
-                        {t("work")}
-                    </NavigationMenuLink>
-                </NavigationMenuItem>
-                {/* Study */}
-                <NavigationMenuItem>
-                    <NavigationMenuLink href="/study"  className="text-menu">
-                        {t("study")}
-                    </NavigationMenuLink>
-                </NavigationMenuItem>
-                {/* About us */}
-                <NavigationMenuItem>
-                    <NavigationMenuLink href="/about" className="text-menu">
-                        {t("aboutUs")}
-                    </NavigationMenuLink>
-                </NavigationMenuItem>
-                {/* Contact */}
-                <NavigationMenuItem>
-                    <NavigationMenuLink href="/contact" className="text-menu">
-                        {t("contact")}
-                    </NavigationMenuLink>
-                </NavigationMenuItem>
-                {/* Blog (We don't know if it's necessary, so I commented our for now) */}
-                {/* <NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink href="/work" className="text-menu">
+            {t("work")}
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        {/* Study */}
+        <NavigationMenuItem>
+          <NavigationMenuLink href="/study" className="text-menu">
+            {t("study")}
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        {/* About us */}
+        <NavigationMenuItem>
+          <NavigationMenuLink href="/about" className="text-menu">
+            {t("aboutUs")}
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        {/* Contact */}
+        <NavigationMenuItem>
+          <NavigationMenuLink href="/contact" className="text-menu">
+            {t("contact")}
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        {/* Blog (We don't know if it's necessary, so I commented our for now) */}
+        {/* <NavigationMenuItem>
                     <NavigationMenuLink href="/blog" className="text-menu">
                         {t("blog")}
                     </NavigationMenuLink>
                 </NavigationMenuItem> */}
-                {/* FAQ */}
-                <NavigationMenuItem>
-                    <NavigationMenuLink href="/faq" className="text-menu">
-                        {t("faq")}
-                    </NavigationMenuLink>
-                </NavigationMenuItem>
-            </NavigationMenuList>
-        </NavigationMenu>
-    )
+        {/* FAQ */}
+        <NavigationMenuItem>
+          <NavigationMenuLink href="/faq" className="text-menu">
+            {t("faq")}
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  );
 }

--- a/src/app/_header/_components/NavigationMenuForMobile.tsx
+++ b/src/app/_header/_components/NavigationMenuForMobile.tsx
@@ -1,52 +1,64 @@
-import { useTranslations } from "next-intl"
-import { HeaderComponent } from "../Header"
 import {
-    Accordion,
-    AccordionContent,
-    AccordionItem,
-    AccordionTrigger,
-} from "@/components/ui/HamburgerMenuAccordion"
-import SubMenu from "./SubMenu"
-import Link from "next/link"
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/HamburgerMenuAccordion";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { HeaderComponent } from "../Header";
+import SubMenu from "./SubMenu";
 
 type Props = {
-    immigrateComponents: HeaderComponent[]
-    workComponents: HeaderComponent[]  // It's not used for now, but I kept it for future use
-}
+  immigrateComponents: HeaderComponent[];
+  workComponents: HeaderComponent[]; // It's not used for now, but I kept it for future use
+};
 
-export default function NavigationMenuForDesktop({ immigrateComponents, workComponents }: Props) {
-    const t = useTranslations("NavigationMenu")
+export default function NavigationMenuForDesktop({
+  immigrateComponents,
+}: Props) {
+  const t = useTranslations("NavigationMenu");
 
-    return (
-        <div className="flex flex-col space-y-8 mt-6">
-            <Accordion type="single" collapsible className="w-full">
-                {/* Immigrate */}
-                <AccordionItem value="immigrate">
-                    <AccordionTrigger>{t("immigrate")}</AccordionTrigger>
-                    <AccordionContent>
-                        <SubMenu components={immigrateComponents} />
-                    </AccordionContent>
-                </AccordionItem>
-                {/* Work */}
-                {/* <AccordionItem value="work">
+  return (
+    <div className="flex flex-col space-y-8 mt-6">
+      <Accordion type="single" collapsible className="w-full">
+        {/* Immigrate */}
+        <AccordionItem value="immigrate">
+          <AccordionTrigger>{t("immigrate")}</AccordionTrigger>
+          <AccordionContent>
+            <SubMenu components={immigrateComponents} />
+          </AccordionContent>
+        </AccordionItem>
+        {/* Work */}
+        {/* <AccordionItem value="work">
                     <AccordionTrigger>{t("work")}</AccordionTrigger>
                     <AccordionContent>
                         <SubMenu components={workComponents} />
                     </AccordionContent>
                 </AccordionItem> */}
-            </Accordion>
-            {/* Work */}
-            <Link href="/work" className="text-menu">{t("work")}</Link>
-            {/* Study */}
-            <Link href="/study" className="text-menu">{t("study")}</Link>
-            {/* About us */}
-            <Link href="/about" className="text-menu">{t("aboutUs")}</Link>
-            {/* Contact */}
-            <Link href="/contact" className="text-menu">{t("contact")}</Link>
-            {/* Blog (We don't know if it's necessary, so I commented our for now) */}
-            {/* <Link href="/blog" className="text-menu">{t("blog")}</Link> */}
-            {/* FAQ */}
-            <Link href="/faq" className="text-menu">{t("faq")}</Link>
-        </div>
-    )
+      </Accordion>
+      {/* Work */}
+      <Link href="/work" className="text-menu">
+        {t("work")}
+      </Link>
+      {/* Study */}
+      <Link href="/study" className="text-menu">
+        {t("study")}
+      </Link>
+      {/* About us */}
+      <Link href="/about" className="text-menu">
+        {t("aboutUs")}
+      </Link>
+      {/* Contact */}
+      <Link href="/contact" className="text-menu">
+        {t("contact")}
+      </Link>
+      {/* Blog (We don't know if it's necessary, so I commented our for now) */}
+      {/* <Link href="/blog" className="text-menu">{t("blog")}</Link> */}
+      {/* FAQ */}
+      <Link href="/faq" className="text-menu">
+        {t("faq")}
+      </Link>
+    </div>
+  );
 }

--- a/src/app/_home-components/NavCard.tsx
+++ b/src/app/_home-components/NavCard.tsx
@@ -1,39 +1,38 @@
 import { Card, CardFooter, CardHeader } from "@/components/ui/card";
-import Image, { StaticImageData } from "next/legacy/image";
+import Image, { StaticImageData } from "next/image";
 import Link from "next/link";
-
 
 type Props = {
   alt: string;
   src: StaticImageData;
   title: string;
   text: string;
-  href: string
+  href: string;
 };
 
 export const NavCard = ({ alt, src, title, text, href }: Props) => {
   return (
     <Link href={href}>
-    <Card className="max-w-[398px] h-[260px] xl:max-w-[344px] xl:h-[360px] flex flex-col">
-      <CardHeader className="flex-grow p-0 pb-6">
-        <div className="relative h-full">
-        <Image
-          alt={alt}
-          src={src}
-          layout={"fill"}
-          objectFit={"cover"}
-          quality={100}
-          className="rounded-t-xl"
-        />
-        <div className="absolute w-full h-full grid place-content-center bg-secondary-blue-op-20 rounded-t-xl">
-          <h1 className="text-page-titles-mobile xl:text-heading-mobile font-bold text-primary-white">
-            {title}
-          </h1>
-        </div>
-        </div>
-      </CardHeader>
-      <CardFooter className="h-[90px]">{text}</CardFooter>
-    </Card>
+      <Card className="max-w-[398px] h-[260px] xl:max-w-[344px] xl:h-[360px] flex flex-col overflow-hidden">
+        <CardHeader className="flex-grow p-0 pb-6">
+          <div className="relative h-full">
+            <Image
+              alt={alt}
+              src={src}
+              fill
+              style={{ objectFit: "cover" }}
+              sizes="auto"
+              quality={50}
+            />
+            <div className="absolute w-full h-full grid place-content-center bg-secondary-blue-op-20 rounded-t-xl">
+              <h1 className="text-page-titles-mobile xl:text-heading-mobile font-bold text-primary-white">
+                {title}
+              </h1>
+            </div>
+          </div>
+        </CardHeader>
+        <CardFooter className="h-[90px]">{text}</CardFooter>
+      </Card>
     </Link>
   );
 };

--- a/src/app/_home-components/NavCard.tsx
+++ b/src/app/_home-components/NavCard.tsx
@@ -1,5 +1,5 @@
 import { Card, CardFooter, CardHeader } from "@/components/ui/card";
-import Image, { StaticImageData } from "next/image";
+import Image, { StaticImageData } from "next/legacy/image";
 import Link from "next/link";
 
 

--- a/src/app/_home-components/OurConsultant.tsx
+++ b/src/app/_home-components/OurConsultant.tsx
@@ -5,7 +5,7 @@ import { SubHeading } from "@/components/common/text/SubHeading";
 import CICCLogo from "@/public/CICCLogo.png";
 import Larissa from "@/public/Larissa.png";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const OurConsultant = () => {
   const t = useTranslations("Home");

--- a/src/app/_home-components/OurConsultant.tsx
+++ b/src/app/_home-components/OurConsultant.tsx
@@ -1,3 +1,4 @@
+import { ResponsiveImage } from "@/components/common/ResponsiveImage";
 import { SectionContainer } from "@/components/common/SectionContainer";
 import { Heading } from "@/components/common/text/Heading";
 import { Paragraph } from "@/components/common/text/Paragraph";
@@ -5,7 +6,6 @@ import { SubHeading } from "@/components/common/text/SubHeading";
 import CICCLogo from "@/public/CICCLogo.png";
 import Larissa from "@/public/Larissa.png";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
 
 export const OurConsultant = () => {
   const t = useTranslations("Home");
@@ -19,15 +19,12 @@ export const OurConsultant = () => {
         <Heading>{t("ourConsultant")}</Heading>
 
         <SubHeading className="py-4 xl:pb-0">Larissa Castelluber</SubHeading>
-        <div className="relative max-w-[398px] h-[316px] xl:hidden">
-          <Image
-            alt="Larissa"
-            src={Larissa}
-            layout={"fill"}
-            objectFit={"cover"}
-            className="rounded-3xl"
-          />
-        </div>
+        <ResponsiveImage
+          alt="Larissa"
+          src={Larissa}
+          divClassName="max-w-[398px] h-[316px] xl:hidden"
+          imgClassName="rounded-3xl"
+        />
         <Paragraph className="py-4 pb-8 xl:py-8">
           {t("ourConsultantDescription")}
         </Paragraph>
@@ -38,25 +35,19 @@ export const OurConsultant = () => {
               {t("verified")} ICCRC
             </Paragraph>
           </div>
-          <div className="relative w-[185px] h-[45px] xl:w-[309px] xl:h-[75px]">
-            <Image
-              alt="CICCLogo"
-              src={CICCLogo}
-              layout={"fill"}
-              objectFit={"cover"}
-            />
-          </div>
+          <ResponsiveImage
+            alt="CICCLogo"
+            src={CICCLogo}
+            divClassName="w-[185px] h-[45px] xl:w-[309px] xl:h-[75px]"
+          />
         </div>
       </div>
-      <div className="relative w-[398px] h-[316px] ml-[42px] hidden xl:block">
-        <Image
-          alt="Larissa"
-          src={Larissa}
-          layout={"fill"}
-          objectFit={"cover"}
-          className="rounded-3xl"
-        />
-      </div>
+      <ResponsiveImage
+        alt="Larissa"
+        src={Larissa}
+        divClassName="w-[398px] h-[316px] ml-[42px] hidden xl:block"
+        imgClassName="rounded-3xl"
+      />
     </SectionContainer>
   );
 };

--- a/src/app/_home-components/Title.tsx
+++ b/src/app/_home-components/Title.tsx
@@ -2,14 +2,21 @@ import { BookFreeConsultation } from "@/components/common/BookFreeConsultation";
 import { Hero } from "@/components/common/text/Hero";
 import home from "@/public/home.jpeg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const Title = () => {
   const t = useTranslations("Home");
 
   return (
     <section className="relative h-[508px] xl:h-[624px]">
-      <Image alt="home" src={home} layout={"fill"} objectFit={"cover"} />
+      <Image
+        alt="home"
+        src={home}
+        fill
+        style={{ objectFit: "cover" }}
+        sizes="auto"
+        quality={50}
+      />
       <div className="absolute w-full h-full grid place-content-center bg-secondary-blue-op-20">
         <div className="w-[355px] xl:w-[1080px] justify-start">
           <div className="w-[358px] xl:w-[650px]">

--- a/src/app/_home-components/Title.tsx
+++ b/src/app/_home-components/Title.tsx
@@ -2,7 +2,7 @@ import { BookFreeConsultation } from "@/components/common/BookFreeConsultation";
 import { Hero } from "@/components/common/text/Hero";
 import home from "@/public/home.jpeg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const Title = () => {
   const t = useTranslations("Home");

--- a/src/app/_home-components/WhyChooseUs.tsx
+++ b/src/app/_home-components/WhyChooseUs.tsx
@@ -28,7 +28,7 @@ export const WhyChooseUs = () => {
         <div className="text-center">
           <div className="pb-7 flex justify-center">
             <ResponsiveImage
-              alt="Languate"
+              alt="Language"
               src={Language}
               divClassName="h-[90px] w-[90px]"
             />

--- a/src/app/_home-components/quiz/Quiz.tsx
+++ b/src/app/_home-components/quiz/Quiz.tsx
@@ -1,55 +1,59 @@
-import { QuizType } from "./QuizDialog";
-import {
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-
-} from "@/components/ui/QuizDialog";
 import { CtaButton } from "@/components/common/text/CtaButton";
-import { Cross2Icon } from '@radix-ui/react-icons';
-import AnswerButtons from './AnswerButtons';
-import QuizPagination from './QuizPagination';
-import StepCounter from './StepCounter';
+import {
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/QuizDialog";
+import { DialogDescription } from "@radix-ui/react-dialog";
+import { Cross2Icon } from "@radix-ui/react-icons";
+import AnswerButtons from "./AnswerButtons";
+import { QuizType } from "./QuizDialog";
+import QuizPagination from "./QuizPagination";
+import StepCounter from "./StepCounter";
 
 type Props = {
-    quiz: QuizType[];
-    currentStep: number;
-    onClose: () => void;
-    onNext: () => void;
-    onBack: () => void;
-    onGoLast: () => void;
-}
+  quiz: QuizType[];
+  currentStep: number;
+  onClose: () => void;
+  onNext: () => void;
+  onBack: () => void;
+  onGoLast: () => void;
+};
 
-export default function Quiz({ quiz, currentStep, onClose, onNext, onBack, onGoLast }: Props) {
-    console.log(quiz);
-    
-    return (
-        <>
-            <DialogHeader>
-                <DialogTitle className="mt-10">
-                    <button onClick={onClose}>
-                        <Cross2Icon className="fixed right-5 top-5 h-7 w-7" />
-                    </button>
-                    <StepCounter
-                        currentStep={currentStep}
-                        totalSteps={quiz.length}
-                    />
-                </DialogTitle>
-            </DialogHeader>
-            <CtaButton className="mt-5 text-center">
-                {quiz[currentStep - 1]?.question}
-            </CtaButton>
-            <AnswerButtons answers={quiz[currentStep - 1]?.answers || []} />
-            <DialogFooter className="sm:justify-start mt-16">
-                <QuizPagination
-                    currentStep={currentStep}
-                    totalSteps={quiz.length}
-                    onNext={onNext}
-                    onBack={onBack}
-                    onGoLast={onGoLast}
-                />
-            </DialogFooter>
-        </>
-    )
+export default function Quiz({
+  quiz,
+  currentStep,
+  onClose,
+  onNext,
+  onBack,
+  onGoLast,
+}: Props) {
+  console.log(quiz);
 
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="mt-10">
+          <button onClick={onClose}>
+            <Cross2Icon className="fixed right-5 top-5 h-7 w-7" />
+          </button>
+          <StepCounter currentStep={currentStep} totalSteps={quiz.length} />
+        </DialogTitle>
+        <DialogDescription />
+      </DialogHeader>
+      <CtaButton className="mt-5 text-center">
+        {quiz[currentStep - 1]?.question}
+      </CtaButton>
+      <AnswerButtons answers={quiz[currentStep - 1]?.answers || []} />
+      <DialogFooter className="sm:justify-start mt-16">
+        <QuizPagination
+          currentStep={currentStep}
+          totalSteps={quiz.length}
+          onNext={onNext}
+          onBack={onBack}
+          onGoLast={onGoLast}
+        />
+      </DialogFooter>
+    </>
+  );
 }

--- a/src/app/_home-components/quiz/QuizDialog.tsx
+++ b/src/app/_home-components/quiz/QuizDialog.tsx
@@ -1,8 +1,5 @@
 "use client";
-import {
-  Dialog,
-  DialogContent,
-} from "@/components/ui/QuizDialog";
+import { Dialog, DialogContent } from "@/components/ui/QuizDialog";
 import { useState } from "react";
 import Quiz from "./Quiz";
 import QuizResult from "./QuizResult";

--- a/src/app/about/_components/OurStrength.tsx
+++ b/src/app/about/_components/OurStrength.tsx
@@ -3,45 +3,52 @@ import { Heading } from "@/components/common/text/Heading";
 import CAPIC from "@/public/CAPICLogo.png";
 import RCIC from "@/public/RCICLogo.png";
 import { Award, BriefcaseBusiness, Heart, User } from "lucide-react";
-import Image from "next/legacy/image";
+import { useTranslations } from "next-intl";
+import Image from "next/image";
 import { Strength } from "./Strength";
-import { useTranslations } from 'next-intl';
 
 export const OurStrength = () => {
   const iconSize = 59;
-  const t = useTranslations('AboutUs');
+  const t = useTranslations("AboutUs");
   return (
-    <SectionContainer className="py-10 xl:py-0" bgColor="bg-neutral-secondary-white xl:bg-inherit">
-      <Heading>{t('section3Title')}</Heading>
+    <SectionContainer
+      className="py-10 xl:py-0"
+      bgColor="bg-neutral-secondary-white xl:bg-inherit"
+    >
+      <Heading>{t("section3Title")}</Heading>
       <div className="pt-4 pb-8 grid xl:grid-cols-2 xl:gap-y-4 xl:gap-x-6 gap-6">
         <Strength
           icon={<User size={iconSize} />}
-          title={t('section3Sub1')}
-          text={t('section3P1')}
+          title={t("section3Sub1")}
+          text={t("section3P1")}
           order="order-1"
         />
         <Strength
           icon={<BriefcaseBusiness size={iconSize} />}
-          title={t('section3Sub2')}
-          text={t('section3P2')}
+          title={t("section3Sub2")}
+          text={t("section3P2")}
           order="xl:order-3 order-2"
         />
         <Strength
           icon={<Heart size={iconSize} />}
-          title={t('section3Sub3')}
-          text={t('section3P3')}
+          title={t("section3Sub3")}
+          text={t("section3P3")}
           order="xl:order-2 order-3"
         />
         <Strength
           icon={<Award size={iconSize} />}
-          title={t('section3Sub4')}
-          text={t('section3P4')}
+          title={t("section3Sub4")}
+          text={t("section3P4")}
           order="order-4"
         />
       </div>
       <div className="flex flex-col items-center xl:flex-row xl:justify-start ">
         <Image alt="RCIC" src={RCIC} className="h-[62px] xl:h-[81px] w-auto" />
-        <Image alt="CAPIC" src={CAPIC} className="h-[62px] xl:h-[81px] w-auto mt-4 xl:mt-0 xl:ml-14 " />
+        <Image
+          alt="CAPIC"
+          src={CAPIC}
+          className="h-[62px] xl:h-[81px] w-auto mt-4 xl:mt-0 xl:ml-14 "
+        />
       </div>
     </SectionContainer>
   );

--- a/src/app/about/_components/OurStrength.tsx
+++ b/src/app/about/_components/OurStrength.tsx
@@ -3,7 +3,7 @@ import { Heading } from "@/components/common/text/Heading";
 import CAPIC from "@/public/CAPICLogo.png";
 import RCIC from "@/public/RCICLogo.png";
 import { Award, BriefcaseBusiness, Heart, User } from "lucide-react";
-import Image from "next/image";
+import Image from "next/legacy/image";
 import { Strength } from "./Strength";
 import { useTranslations } from 'next-intl';
 

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -8,14 +8,14 @@ export async function POST(req: Request) {
     // Log the received data
     console.log("Received form data:", { firstName, lastName, email, message });
 
-    // Check if all required enviroment variabels are set
+    // Check if all required environment variables are set
     if (
       !process.env.EMAIL_SERVER ||
       !process.env.EMAIL_USER ||
       !process.env.EMAIL_PASS ||
       !process.env.RECIPIENT_EMAIL
     ) {
-      console.error("Missing required enviroment variables");
+      console.error("Missing required environment variables");
       return NextResponse.json(
         { error: "Server configurations error" },
         { status: 500 }
@@ -49,7 +49,7 @@ export async function POST(req: Request) {
 
     console.log("Message sent: %s", info.messageId);
     return NextResponse.json(
-      { message: "Email sent successufully" },
+      { message: "Email sent successfully" },
       { status: 200 }
     );
   } catch (error) {

--- a/src/app/immigrate/_components/CardsPrograms.tsx
+++ b/src/app/immigrate/_components/CardsPrograms.tsx
@@ -2,7 +2,7 @@
 import { SectionContainer } from "@/components/common/SectionContainer";
 import { Button } from "@/components/ui/UpImmigrationButton";
 import { ChevronDown, ChevronUp } from "lucide-react";
-import Image from "next/legacy/image";
+import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
 import { ImmigrationPrograms } from "../content/immigrationPrograms";

--- a/src/app/immigrate/_components/CardsPrograms.tsx
+++ b/src/app/immigrate/_components/CardsPrograms.tsx
@@ -2,7 +2,7 @@
 import { SectionContainer } from "@/components/common/SectionContainer";
 import { Button } from "@/components/ui/UpImmigrationButton";
 import { ChevronDown, ChevronUp } from "lucide-react";
-import Image from "next/image";
+import Image from "next/legacy/image";
 import Link from "next/link";
 import { useState } from "react";
 import { ImmigrationPrograms } from "../content/immigrationPrograms";

--- a/src/app/immigrate/_components/CardsPrograms.tsx
+++ b/src/app/immigrate/_components/CardsPrograms.tsx
@@ -19,7 +19,7 @@ export const CardsPrograms = () => {
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold mb-6">Discover all your options</h2>
         <div className="grid grid-cols-3 gap-6 mb-8">
-          {ImmigrationPrograms.map((program) => (
+          {ImmigrationPrograms().map((program) => (
             <a
               href={`#${program.title}`}
               key={program.title}
@@ -30,7 +30,7 @@ export const CardsPrograms = () => {
           ))}
         </div>
         <div className="grid md:grid-cols-1 lg:grid-cols-3 gap-6">
-          {ImmigrationPrograms.map((program) => (
+          {ImmigrationPrograms().map((program) => (
             <div
               id={program.title}
               key={program.title}

--- a/src/app/immigrate/_components/EEPrograms.tsx
+++ b/src/app/immigrate/_components/EEPrograms.tsx
@@ -13,9 +13,11 @@ export const EEPrograms = () => {
     <>
       <SectionContainer className="py-10">
         <Image
-          className="pt-10 pb-10 w-full rounded-xl"
+          className="pt-10 pb-10 rounded-xl"
           src={EEProgramsImage}
           alt="Express Entry"
+          width={1200}
+          height={800}
         />
       </SectionContainer>
 

--- a/src/app/immigrate/_components/EEPrograms.tsx
+++ b/src/app/immigrate/_components/EEPrograms.tsx
@@ -13,7 +13,7 @@ export const EEPrograms = () => {
     <>
       <SectionContainer className="py-10">
         <Image
-          className="pt-10 pb-10 rounded-xl"
+          className="my-10 rounded-xl"
           src={EEProgramsImage}
           alt="Express Entry"
           width={1200}

--- a/src/app/immigrate/_components/EEPrograms.tsx
+++ b/src/app/immigrate/_components/EEPrograms.tsx
@@ -5,7 +5,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import EEProgramsImage from "@/public/EEPrograms.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const EEPrograms = () => {
   const t = useTranslations("EEPrograms");

--- a/src/app/immigrate/_components/EEPrograms.tsx
+++ b/src/app/immigrate/_components/EEPrograms.tsx
@@ -5,7 +5,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import EEProgramsImage from "@/public/EEPrograms.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const EEPrograms = () => {
   const t = useTranslations("EEPrograms");

--- a/src/app/immigrate/_components/FAQComponent.tsx
+++ b/src/app/immigrate/_components/FAQComponent.tsx
@@ -17,7 +17,7 @@ export const FAQComponent = () => {
         Immigration Frequent Questions
       </h2>
       <div className="space-y-4">
-        {FAQs.map((faq, index) => (
+        {FAQs().map((faq, index) => (
           <div key={index} className="border-b border-gray-200 pb-4">
             <button
               className="flex justify-between items-center w-full text-left"

--- a/src/app/immigrate/_components/IntoductionRNIP.tsx
+++ b/src/app/immigrate/_components/IntoductionRNIP.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const IntoductionRNIP = () => {
   const t = useTranslations("IntroductionRNIP");

--- a/src/app/immigrate/_components/IntoductionRNIP.tsx
+++ b/src/app/immigrate/_components/IntoductionRNIP.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const IntoductionRNIP = () => {
   const t = useTranslations("IntroductionRNIP");

--- a/src/app/immigrate/_components/IntoductionRNIP.tsx
+++ b/src/app/immigrate/_components/IntoductionRNIP.tsx
@@ -27,9 +27,11 @@ export const IntoductionRNIP = () => {
 
         <SectionContainer className="pb-10">
           <Image
-            className="w-full rounded-xl"
+            className="rounded-xl"
             src={howEEworks}
             alt={t("imageAlt")}
+            width={1200}
+            height={800}
           />
         </SectionContainer>
 

--- a/src/app/immigrate/_components/IntroductionAtlantic.tsx
+++ b/src/app/immigrate/_components/IntroductionAtlantic.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const IntroductionAtlantic = () => {
   const t = useTranslations("IntroductionAtlantic");

--- a/src/app/immigrate/_components/IntroductionAtlantic.tsx
+++ b/src/app/immigrate/_components/IntroductionAtlantic.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const IntroductionAtlantic = () => {
   const t = useTranslations("IntroductionAtlantic");

--- a/src/app/immigrate/_components/IntroductionAtlantic.tsx
+++ b/src/app/immigrate/_components/IntroductionAtlantic.tsx
@@ -27,9 +27,11 @@ export const IntroductionAtlantic = () => {
 
         <SectionContainer className="pb-10">
           <Image
-            className="w-full rounded-xl"
+            className="rounded-xl"
             src={howEEworks}
             alt={t("imageAlt")}
+            width={1200}
+            height={800}
           />
         </SectionContainer>
 

--- a/src/app/immigrate/_components/IntroductionCaregiver.tsx
+++ b/src/app/immigrate/_components/IntroductionCaregiver.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const IntroductionCaregiver = () => {
   const t = useTranslations("IntroductionCaregiver");

--- a/src/app/immigrate/_components/IntroductionCaregiver.tsx
+++ b/src/app/immigrate/_components/IntroductionCaregiver.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const IntroductionCaregiver = () => {
   const t = useTranslations("IntroductionCaregiver");

--- a/src/app/immigrate/_components/IntroductionCaregiver.tsx
+++ b/src/app/immigrate/_components/IntroductionCaregiver.tsx
@@ -27,9 +27,11 @@ export const IntroductionCaregiver = () => {
 
         <SectionContainer className="pb-10">
           <Image
-            className="w-full rounded-xl"
+            className="rounded-xl"
             src={howEEworks}
             alt={t("imageAlt")}
+            width={1200}
+            height={800}
           />
         </SectionContainer>
 

--- a/src/app/immigrate/_components/IntroductionEE.tsx
+++ b/src/app/immigrate/_components/IntroductionEE.tsx
@@ -27,9 +27,11 @@ export const IntroductionEE = () => {
 
         <SectionContainer className="pb-10">
           <Image
-            className="w-full rounded-xl"
+            className="rounded-xl"
             src={howEEworks}
             alt={t("imageAlt")}
+            width={1200}
+            height={800}
           />
         </SectionContainer>
 

--- a/src/app/immigrate/_components/IntroductionEE.tsx
+++ b/src/app/immigrate/_components/IntroductionEE.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const IntroductionEE = () => {
   const t = useTranslations("IntroductionExpressEntry");

--- a/src/app/immigrate/_components/IntroductionEE.tsx
+++ b/src/app/immigrate/_components/IntroductionEE.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const IntroductionEE = () => {
   const t = useTranslations("IntroductionExpressEntry");

--- a/src/app/immigrate/_components/IntroductionFamily.tsx
+++ b/src/app/immigrate/_components/IntroductionFamily.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const IntroductionFamily = () => {
   const t = useTranslations("IntroductionFamily");

--- a/src/app/immigrate/_components/IntroductionFamily.tsx
+++ b/src/app/immigrate/_components/IntroductionFamily.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const IntroductionFamily = () => {
   const t = useTranslations("IntroductionFamily");

--- a/src/app/immigrate/_components/IntroductionFamily.tsx
+++ b/src/app/immigrate/_components/IntroductionFamily.tsx
@@ -27,9 +27,11 @@ export const IntroductionFamily = () => {
 
         <SectionContainer className="pb-10">
           <Image
-            className="w-full rounded-xl"
+            className="rounded-xl"
             src={howEEworks}
             alt={t("imageAlt")}
+            width={1200}
+            height={800}
           />
         </SectionContainer>
 

--- a/src/app/immigrate/_components/IntroductionHumanitarian.tsx
+++ b/src/app/immigrate/_components/IntroductionHumanitarian.tsx
@@ -3,8 +3,8 @@ import { Heading } from "@/components/common/text/Heading";
 import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
-import Image from "next/legacy/image";
 import { useTranslations } from "next-intl";
+import Image from "next/legacy/image";
 
 export const IntroductionHumanitarian = () => {
   const t = useTranslations("IntroductionHumanitarian");
@@ -27,9 +27,11 @@ export const IntroductionHumanitarian = () => {
 
         <SectionContainer className="pb-10">
           <Image
-            className="w-full rounded-xl"
+            className="rounded-xl"
             src={howEEworks}
             alt={t("imageAlt")}
+            width={1200}
+            height={800}
           />
         </SectionContainer>
 

--- a/src/app/immigrate/_components/IntroductionHumanitarian.tsx
+++ b/src/app/immigrate/_components/IntroductionHumanitarian.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const IntroductionHumanitarian = () => {
   const t = useTranslations("IntroductionHumanitarian");

--- a/src/app/immigrate/_components/IntroductionHumanitarian.tsx
+++ b/src/app/immigrate/_components/IntroductionHumanitarian.tsx
@@ -3,7 +3,7 @@ import { Heading } from "@/components/common/text/Heading";
 import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
-import Image from "next/image";
+import Image from "next/legacy/image";
 import { useTranslations } from "next-intl";
 
 export const IntroductionHumanitarian = () => {

--- a/src/app/immigrate/_components/IntroductionSelfEmployed.tsx
+++ b/src/app/immigrate/_components/IntroductionSelfEmployed.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const IntroductionSelfEmployed = () => {
   const t = useTranslations("IntroductionSelfEmployed");

--- a/src/app/immigrate/_components/IntroductionSelfEmployed.tsx
+++ b/src/app/immigrate/_components/IntroductionSelfEmployed.tsx
@@ -27,9 +27,11 @@ export const IntroductionSelfEmployed = () => {
 
         <SectionContainer className="pb-10">
           <Image
-            className="w-full rounded-xl"
+            className="rounded-xl"
             src={howEEworks}
             alt={t("imageAlt")}
+            width={1200}
+            height={800}
           />
         </SectionContainer>
 

--- a/src/app/immigrate/_components/IntroductionSelfEmployed.tsx
+++ b/src/app/immigrate/_components/IntroductionSelfEmployed.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const IntroductionSelfEmployed = () => {
   const t = useTranslations("IntroductionSelfEmployed");

--- a/src/app/immigrate/_components/IntroductionStartUp.tsx
+++ b/src/app/immigrate/_components/IntroductionStartUp.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const IntroductionStartUp = () => {
   const t = useTranslations("IntroductionStartUp");

--- a/src/app/immigrate/_components/IntroductionStartUp.tsx
+++ b/src/app/immigrate/_components/IntroductionStartUp.tsx
@@ -27,9 +27,11 @@ export const IntroductionStartUp = () => {
 
         <SectionContainer className="pb-10">
           <Image
-            className="w-full rounded-xl"
+            className="rounded-xl"
             src={howEEworks}
             alt={t("imageAlt")}
+            width={1200}
+            height={800}
           />
         </SectionContainer>
 

--- a/src/app/immigrate/_components/IntroductionStartUp.tsx
+++ b/src/app/immigrate/_components/IntroductionStartUp.tsx
@@ -4,7 +4,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import howEEworks from "@/public/howEEworks.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const IntroductionStartUp = () => {
   const t = useTranslations("IntroductionStartUp");

--- a/src/app/immigrate/_components/NavCardItemIP.tsx
+++ b/src/app/immigrate/_components/NavCardItemIP.tsx
@@ -31,21 +31,24 @@ export const NavCardItemIP = forwardRef<HTMLDivElement, Props>(
     return (
       <Card
         id={id}
-        className={`flex flex-col p-6 rounded-[20px] gap-4 self-stretch shadow-[0px_-8px_10px_-1px_rgba(0,0,0,0.10)] ${
+        className={`flex flex-col p-6 min-h-[376px] rounded-[20px] gap-4 self-stretch shadow-[0px_-8px_10px_-1px_rgba(0,0,0,0.10)] ${
           isLast ? "xl:mb-0" : isExpanded ? "" : "mb-[-51px]"
         } xl:w-[343px]  xl:mb-0`}
         ref={ref}
       >
         <div className="flex flex-col gap-2">
-          <div className="flex justify-between items-center">
+          <div className="flex justify-between items-start">
             <CardHeader className="p-0">
-              <CardTitle className="text-xl font-bold">{title}</CardTitle>
+              <CardTitle className="text-xl font-bold min-h-[56px]">
+                {title}
+              </CardTitle>
             </CardHeader>
+
             <Image
               src={CloseIcon}
               alt="Close icon"
               onClick={toggleExpand}
-              className={`cursor-pointer transform transition-transform duration-300 ease-in-out ${
+              className={`pt-1 cursor-pointer transform transition-transform duration-300 ease-in-out ${
                 isExpanded ? "rotate-180" : ""
               }`}
             />

--- a/src/app/immigrate/_components/NavCardItemIP.tsx
+++ b/src/app/immigrate/_components/NavCardItemIP.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/UpImmigrationButton";
 import CloseIcon from "@/public/close-icon.svg";
-import Image, { StaticImageData } from "next/image";
+import Image, { StaticImageData } from "next/legacy/image";
 import Link from "next/link";
 import { ForwardedRef, forwardRef, useState } from "react";
 

--- a/src/app/immigrate/_components/NavCardItemIP.tsx
+++ b/src/app/immigrate/_components/NavCardItemIP.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/UpImmigrationButton";
 import CloseIcon from "@/public/close-icon.svg";
-import Image, { StaticImageData } from "next/legacy/image";
+import Image, { StaticImageData } from "next/image";
 import Link from "next/link";
 import { ForwardedRef, forwardRef, useState } from "react";
 

--- a/src/app/immigrate/_components/NavCardListIP.tsx
+++ b/src/app/immigrate/_components/NavCardListIP.tsx
@@ -8,7 +8,7 @@ import RNIP from "@/public/rnip.jpg";
 import selfEmployed from "@/public/selfEmployed.jpg";
 import startUp from "@/public/startUp.png";
 import { useTranslations } from "next-intl";
-import { StaticImageData } from "next/image";
+import { StaticImageData } from "next/legacy/image";
 import { forwardRef } from "react";
 import { NavCardItemIP } from "./NavCardItemIP";
 

--- a/src/app/immigrate/_components/NavCardListIP.tsx
+++ b/src/app/immigrate/_components/NavCardListIP.tsx
@@ -127,17 +127,19 @@ export const NavCardListIP = forwardRef<HTMLDivElement, Props>(
         ref={ref}
       >
         {NavCardItems().map((item, index) => (
-          <NavCardItemIP
-            key={item.id}
-            ref={refs[item.ref as keyof typeof refs]}
-            id={item.id}
-            title={item.title}
-            alt={item.alt}
-            description={item.description}
-            image={item.image}
-            isLast={index === NavCardItems().length - 1}
-            buttonLink={item.buttonLink}
-          />
+          <div key={item.id}>
+            <NavCardItemIP
+              key={item.id}
+              ref={refs[item.ref as keyof typeof refs]}
+              id={item.id}
+              title={item.title}
+              alt={item.alt}
+              description={item.description}
+              image={item.image}
+              isLast={index === NavCardItems().length - 1}
+              buttonLink={item.buttonLink}
+            />
+          </div>
         ))}
       </div>
     );

--- a/src/app/immigrate/_components/NavCardListIP.tsx
+++ b/src/app/immigrate/_components/NavCardListIP.tsx
@@ -8,7 +8,7 @@ import RNIP from "@/public/rnip.jpg";
 import selfEmployed from "@/public/selfEmployed.jpg";
 import startUp from "@/public/startUp.png";
 import { useTranslations } from "next-intl";
-import { StaticImageData } from "next/legacy/image";
+import { StaticImageData } from "next/image";
 import { forwardRef } from "react";
 import { NavCardItemIP } from "./NavCardItemIP";
 

--- a/src/app/immigrate/_components/PNProgramsComponent.tsx
+++ b/src/app/immigrate/_components/PNProgramsComponent.tsx
@@ -13,8 +13,9 @@ export const PNProgramsComponent = () => {
     <>
       <SectionContainer>
         <Heading>{t("headingPNP")}</Heading>
-        <div className="py-8">
+        <div className="my-8 rounded-xl">
           <Image
+            className="rounded-xl"
             src={PNPrograms}
             alt={t("headingPNP")}
             width={1200}

--- a/src/app/immigrate/_components/PNProgramsComponent.tsx
+++ b/src/app/immigrate/_components/PNProgramsComponent.tsx
@@ -5,7 +5,7 @@ import { SubHeading } from "@/components/common/text/SubHeading";
 import { PNPFAQs } from "@/data/FAQData";
 import PNPrograms from "@/public/Provincial-Nominee-Programs.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 export const PNProgramsComponent = () => {
   const t = useTranslations("ProvincesAndTerritories");

--- a/src/app/immigrate/_components/PNProgramsComponent.tsx
+++ b/src/app/immigrate/_components/PNProgramsComponent.tsx
@@ -18,7 +18,7 @@ export const PNProgramsComponent = () => {
             src={PNPrograms}
             alt={t("headingPNP")}
             width={1200}
-            height={400}
+            height={700}
           />
         </div>
       </SectionContainer>

--- a/src/app/immigrate/_components/PNProgramsComponent.tsx
+++ b/src/app/immigrate/_components/PNProgramsComponent.tsx
@@ -5,7 +5,7 @@ import { SubHeading } from "@/components/common/text/SubHeading";
 import { PNPFAQs } from "@/data/FAQData";
 import PNPrograms from "@/public/Provincial-Nominee-Programs.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 
 export const PNProgramsComponent = () => {
   const t = useTranslations("ProvincesAndTerritories");

--- a/src/app/immigrate/_components/ProvincesAndTerritories.tsx
+++ b/src/app/immigrate/_components/ProvincesAndTerritories.tsx
@@ -5,7 +5,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import Provinces from "@/public/Provinces-and-Territories.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
+import Image from "next/image";
 import { PNPPrograms } from "../content/pnpPrograms";
 
 export const ProvincesAndTerritories = () => {

--- a/src/app/immigrate/_components/ProvincesAndTerritories.tsx
+++ b/src/app/immigrate/_components/ProvincesAndTerritories.tsx
@@ -15,7 +15,12 @@ export const ProvincesAndTerritories = () => {
       <SectionContainer className="mb-6 py-16">
         <SectionContainer>
           <Heading>{t("heading")}</Heading>
-          <Image src={Provinces} alt={t("heading")} width={1200} height={400} />
+          <Image
+            src={Provinces}
+            alt={t("heading")}
+            width={1200}
+            height={1000}
+          />
         </SectionContainer>
 
         <SectionContainer>

--- a/src/app/immigrate/_components/ProvincesAndTerritories.tsx
+++ b/src/app/immigrate/_components/ProvincesAndTerritories.tsx
@@ -5,7 +5,7 @@ import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import Provinces from "@/public/Provinces-and-Territories.jpg";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 import { PNPPrograms } from "../content/pnpPrograms";
 
 export const ProvincesAndTerritories = () => {

--- a/src/app/immigrate/content/immigrationPrograms.ts
+++ b/src/app/immigrate/content/immigrationPrograms.ts
@@ -4,11 +4,11 @@ import expressEntry from "@/public/expressEntry.jpg";
 import familySP from "@/public/familySP.jpg";
 import humanitarian from "@/public/humanitarian.jpg";
 import PNP from "@/public/PNP.png";
-import RNIP from "@/public/rnip.jpg";
+import rnip from "@/public/rnip.jpg";
 import selfEmployed from "@/public/selfEmployed.jpg";
 import startUp from "@/public/startUp.png";
 import { useTranslations } from "next-intl";
-import { StaticImageData } from "next/legacy/image";
+import { StaticImageData } from "next/image";
 type ImmigrationProgramsType = {
   title: string;
   description: string;
@@ -79,7 +79,7 @@ export const ImmigrationPrograms = (): ImmigrationProgramsType[] => {
     {
       title: t("NorthernImmigrationProgram"),
       description: t("NorthernImmigrationDescription"),
-      image: RNIP,
+      image: rnip,
       details: t("NorthernImmigrationDetails"),
       endpoint: "rnip",
     },

--- a/src/app/immigrate/content/immigrationPrograms.ts
+++ b/src/app/immigrate/content/immigrationPrograms.ts
@@ -8,7 +8,7 @@ import RNIP from "@/public/rnip.jpg";
 import selfEmployed from "@/public/selfEmployed.jpg";
 import startUp from "@/public/startUp.png";
 import { useTranslations } from "next-intl";
-import { StaticImageData } from "next/image";
+import { StaticImageData } from "next/legacy/image";
 type ImmigrationProgramsType = {
   title: string;
   description: string;

--- a/src/app/immigrate/rnip/page.tsx
+++ b/src/app/immigrate/rnip/page.tsx
@@ -1,7 +1,7 @@
 import { ApplicationStepDesktop } from "@/components/common/ApplicationStepDesktop";
 import { ApplicationStepMobile } from "@/components/common/ApplicationStepMobile";
 import { HeaderPicture } from "@/components/common/HeaderPicture";
-import RNIP from "@/public/RNIP.jpg";
+import rnip from "@/public/rnip.jpg";
 import { useTranslations } from "next-intl";
 import { EEPrograms } from "../_components/EEPrograms";
 import { IntoductionRNIP } from "../_components/IntoductionRNIP";
@@ -12,7 +12,7 @@ export default function NorthernImmigrationRNIP() {
   const t2 = useTranslations("IntroductionRNIP");
   return (
     <>
-      <HeaderPicture alt={t2("title")} src={RNIP} title={t2("title")} />
+      <HeaderPicture alt={t2("title")} src={rnip} title={t2("title")} />
 
       <IntoductionRNIP />
 

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -91,11 +91,11 @@ export default function AboutPage() {
       </SectionContainer>
       <ApplicationStepMobile
         title="Where to start?"
-        steps={Steps}
+        steps={Steps()}
         height="h-[60px]"
       />
       <ApplicationStepMobile
-        steps={EPSteps}
+        steps={EPSteps()}
         title="What is the process?"
         circleSpacing={120}
         height="h-[140px]"

--- a/src/app/study/_components/StudyCardItem.tsx
+++ b/src/app/study/_components/StudyCardItem.tsx
@@ -1,7 +1,7 @@
 import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import { CardHeader } from "@/components/ui/card";
-import Image, { StaticImageData } from "next/legacy/image";
+import Image, { StaticImageData } from "next/image";
 
 interface Props {
   title: string;

--- a/src/app/study/_components/StudyCardItem.tsx
+++ b/src/app/study/_components/StudyCardItem.tsx
@@ -1,7 +1,7 @@
 import { Paragraph } from "@/components/common/text/Paragraph";
 import { SubHeading } from "@/components/common/text/SubHeading";
 import { CardHeader } from "@/components/ui/card";
-import Image, { StaticImageData } from "next/image";
+import Image, { StaticImageData } from "next/legacy/image";
 
 interface Props {
   title: string;

--- a/src/app/work/_components/DiscoverOptionsButton.tsx
+++ b/src/app/work/_components/DiscoverOptionsButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/BookConsultationButton";
+import { Button } from "@/components/ui/UpImmigrationButton";
 import Link from "next/link";
 
 interface Props {

--- a/src/app/work/_components/NavCardItem.tsx
+++ b/src/app/work/_components/NavCardItem.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/UpImmigrationButton";
 import CloseIcon from "@/public/close-icon.svg";
-import Image, { StaticImageData } from "next/image";
+import Image, { StaticImageData } from "next/legacy/image";
 import Link from "next/link";
 import { ForwardedRef, forwardRef, useState } from "react";
 

--- a/src/app/work/_components/NavCardItem.tsx
+++ b/src/app/work/_components/NavCardItem.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/UpImmigrationButton";
 import CloseIcon from "@/public/close-icon.svg";
-import Image, { StaticImageData } from "next/legacy/image";
+import Image, { StaticImageData } from "next/image";
 import Link from "next/link";
 import { ForwardedRef, forwardRef, useState } from "react";
 

--- a/src/app/work/_components/NavCardItem.tsx
+++ b/src/app/work/_components/NavCardItem.tsx
@@ -37,15 +37,15 @@ export const NavCardItem = forwardRef<HTMLDivElement, Props>(
         ref={ref}
       >
         <div className="flex flex-col gap-2">
-          <div className="flex justify-between items-center">
-            <CardHeader className="p-0">
+          <div className="flex justify-between items-start">
+            <CardHeader className="p-0 min-h-[84px]">
               <CardTitle className="text-xl font-bold">{title}</CardTitle>
             </CardHeader>
             <Image
               src={CloseIcon}
               alt="Close icon"
               onClick={toggleExpand}
-              className={`cursor-pointer transform transition-transform duration-300 ease-in-out ${
+              className={`pt-2 cursor-pointer transform transition-transform duration-300 ease-in-out ${
                 isExpanded ? "rotate-180" : ""
               }`}
             />

--- a/src/app/work/_components/WorkBackground.tsx
+++ b/src/app/work/_components/WorkBackground.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import Image from "next/legacy/image";
 import workImage from "../../../public/work.jpeg";
 
 export function WorkBackground() {

--- a/src/app/work/_components/WorkBackground.tsx
+++ b/src/app/work/_components/WorkBackground.tsx
@@ -1,4 +1,4 @@
-import Image from "next/legacy/image";
+import Image from "next/image";
 import workImage from "../../../public/work.jpeg";
 
 export function WorkBackground() {

--- a/src/components/common/ContactMenu.tsx
+++ b/src/components/common/ContactMenu.tsx
@@ -1,21 +1,18 @@
-import { ContactItem } from "@/data/ContactData"
-import { useTranslations } from "next-intl"
+import { ContactItem } from "@/data/ContactData";
 
 type Props = {
-    className: string | undefined
-    components: ContactItem[]
-}
+  className: string | undefined;
+  components: ContactItem[];
+};
 
 export default function ContactMenu({ className, components }: Props) {
-    const t = useTranslations("LocaleSwitcher")
-
-    return (
-        <div className={`flex space-x-4 ${className}`}>
-            {components.map((component) => (
-                <a target="_blank" key={component.name} href={component.href}>
-                    <component.imageComponent size={35} />
-                </a>
-            ))}
-        </div>
-    )
+  return (
+    <div className={`flex space-x-4 ${className}`}>
+      {components.map((component) => (
+        <a target="_blank" key={component.name} href={component.href}>
+          <component.imageComponent size={35} />
+        </a>
+      ))}
+    </div>
+  );
 }

--- a/src/components/common/HeaderPicture.tsx
+++ b/src/components/common/HeaderPicture.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import Image, { StaticImageData } from "next/image";
+import Image, { StaticImageData } from "next/legacy/image";
 import { Title } from "./text/Title";
 
 type Props = {

--- a/src/components/common/HeaderPicture.tsx
+++ b/src/components/common/HeaderPicture.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import Image, { StaticImageData } from "next/legacy/image";
+import Image, { StaticImageData } from "next/image";
 import { Title } from "./text/Title";
 
 type Props = {
@@ -28,11 +28,14 @@ export const HeaderPicture = ({ alt, src, title, className }: Props) => {
       <Image
         alt={alt}
         src={src}
-        layout={"fill"}
-        objectFit={"cover"}
+        fill
+        style={{ objectFit: "cover" }}
+        sizes="auto"
+        quality={50}
         priority
         className={cn(className)}
       />
+
       <div className="absolute w-full h-full grid place-content-center bg-secondary-blue-op-20">
         <Title className="text-primary-white">{title}</Title>
       </div>

--- a/src/components/common/LocaleSwitcher.tsx
+++ b/src/components/common/LocaleSwitcher.tsx
@@ -4,7 +4,7 @@ import { setUserLocale } from "@/services/locale";
 import { useLocale } from "next-intl";
 import { useTransition } from "react";
 // import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/LanguageSelect";
-// import Image from "next/legacy/image";
+// import Image from "next/image";
 // import unitedStates from "@/public/unitedStates.png"
 // import spain from "@/public/spain.png"
 // import brazil from "@/public/brazil.png"

--- a/src/components/common/LocaleSwitcher.tsx
+++ b/src/components/common/LocaleSwitcher.tsx
@@ -1,64 +1,64 @@
 "use client";
 import { Locale } from "@/i18n/config";
 import { setUserLocale } from "@/services/locale";
-import { useLocale, useTranslations } from 'next-intl';
+import { useLocale } from "next-intl";
 import { useTransition } from "react";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/LanguageSelect";
-import Image from "next/legacy/image";
-import unitedStates from "@/public/unitedStates.png"
-import spain from "@/public/spain.png"
-import brazil from "@/public/brazil.png"
+// import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/LanguageSelect";
+// import Image from "next/legacy/image";
+// import unitedStates from "@/public/unitedStates.png"
+// import spain from "@/public/spain.png"
+// import brazil from "@/public/brazil.png"
 
 type Props = {
-    className: string;
-}
+  className: string;
+};
 
 export default function LanguageSwitcher({ className }: Props) {
-    const t = useTranslations('LocaleSwitcher');
-    const locale = useLocale();
-    const [isPending, startTransition] = useTransition();
+  const locale = useLocale();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [isPending, startTransition] = useTransition();
 
-    const handleLanguageChange = (value: string) => {
-        const locale = value as Locale;
-        startTransition(() => {
-            setUserLocale(locale);
-        });
-    };
+  const handleLanguageChange = (value: string) => {
+    const locale = value as Locale;
+    startTransition(() => {
+      setUserLocale(locale);
+    });
+  };
 
-    return (
-        // FIXME: I couldn't use the Select component from Shadcn because the weired margin will appear on the right side of the container
-        // <Select value={locale} onValueChange={handleLanguageChange}>
-        //     <SelectTrigger className="w-[70px]">
-        //         <SelectValue placeholder="Select Language" />
-        //     </SelectTrigger>
-        //     <SelectContent>
-        //         <SelectItem value="en">
-        //             <Image src={unitedStates} alt="english" width={25}/>
-        //         </SelectItem>
-        //         <SelectItem value="es">
-        //             <Image src={spain} alt="spanish" width={25}/> 
-        //         </SelectItem>
-        //         <SelectItem value="pt">
-        //             <Image src={brazil} alt="portuguese" width={25}/> 
-        //         </SelectItem>
-        //     </SelectContent>
-        // </Select>
-        (<>
-            <select
-                value={locale}
-                onChange={(e) => handleLanguageChange(e.target.value)}
-                className={`w-[90px] p-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:border-transparent transition-colors ${className}`}
-            >
-                <option value="en" className="flex items-center">
-                    EN
-                </option>
-                <option value="es" className="flex items-center">
-                    ES
-                </option>
-                <option value="pt" className="flex items-center">
-                    PT-BR
-                </option>
-            </select>
-        </>)
-    );
-};
+  return (
+    // FIXME: I couldn't use the Select component from Shadcn because the weird margin will appear on the right side of the container
+    // <Select value={locale} onValueChange={handleLanguageChange}>
+    //     <SelectTrigger className="w-[70px]">
+    //         <SelectValue placeholder="Select Language" />
+    //     </SelectTrigger>
+    //     <SelectContent>
+    //         <SelectItem value="en">
+    //             <Image src={unitedStates} alt="english" width={25}/>
+    //         </SelectItem>
+    //         <SelectItem value="es">
+    //             <Image src={spain} alt="spanish" width={25}/>
+    //         </SelectItem>
+    //         <SelectItem value="pt">
+    //             <Image src={brazil} alt="portuguese" width={25}/>
+    //         </SelectItem>
+    //     </SelectContent>
+    // </Select>
+    <>
+      <select
+        value={locale}
+        onChange={(e) => handleLanguageChange(e.target.value)}
+        className={`w-[90px] p-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:border-transparent transition-colors ${className}`}
+      >
+        <option value="en" className="flex items-center">
+          EN
+        </option>
+        <option value="es" className="flex items-center">
+          ES
+        </option>
+        <option value="pt" className="flex items-center">
+          PT-BR
+        </option>
+      </select>
+    </>
+  );
+}

--- a/src/components/common/LocaleSwitcher.tsx
+++ b/src/components/common/LocaleSwitcher.tsx
@@ -4,7 +4,7 @@ import { setUserLocale } from "@/services/locale";
 import { useLocale, useTranslations } from 'next-intl';
 import { useTransition } from "react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/LanguageSelect";
-import Image from 'next/image';
+import Image from "next/legacy/image";
 import unitedStates from "@/public/unitedStates.png"
 import spain from "@/public/spain.png"
 import brazil from "@/public/brazil.png"
@@ -26,24 +26,6 @@ export default function LanguageSwitcher({ className }: Props) {
     };
 
     return (
-        <>
-            <select
-                value={locale}
-                onChange={(e) => handleLanguageChange(e.target.value)}
-                className={`w-[90px] p-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:border-transparent transition-colors ${className}`}
-            >
-                <option value="en" className="flex items-center">
-                    EN
-                </option>
-                <option value="es" className="flex items-center">
-                    ES
-                </option>
-                <option value="pt" className="flex items-center">
-                    PT-BR
-                </option>
-            </select>
-        </>
-
         // FIXME: I couldn't use the Select component from Shadcn because the weired margin will appear on the right side of the container
         // <Select value={locale} onValueChange={handleLanguageChange}>
         //     <SelectTrigger className="w-[70px]">
@@ -61,5 +43,22 @@ export default function LanguageSwitcher({ className }: Props) {
         //         </SelectItem>
         //     </SelectContent>
         // </Select>
+        (<>
+            <select
+                value={locale}
+                onChange={(e) => handleLanguageChange(e.target.value)}
+                className={`w-[90px] p-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:border-transparent transition-colors ${className}`}
+            >
+                <option value="en" className="flex items-center">
+                    EN
+                </option>
+                <option value="es" className="flex items-center">
+                    ES
+                </option>
+                <option value="pt" className="flex items-center">
+                    PT-BR
+                </option>
+            </select>
+        </>)
     );
 };

--- a/src/components/common/NavCardList.tsx
+++ b/src/components/common/NavCardList.tsx
@@ -81,17 +81,19 @@ export const NavCardList = forwardRef<HTMLDivElement, Props>(
         ref={ref}
       >
         {navCardItems.map((item, index) => (
-          <NavCardItem
-            key={item.id}
-            ref={refs[item.ref as keyof typeof refs]}
-            id={item.id}
-            title={t(item.title)}
-            alt={item.alt}
-            description={t(item.description)}
-            image={item.image}
-            isLast={index === navCardItems.length - 1}
-            buttonLink={item.buttonLink}
-          />
+          <div key={item.id}>
+            <NavCardItem
+              key={item.id}
+              ref={refs[item.ref as keyof typeof refs]}
+              id={item.id}
+              title={t(item.title)}
+              alt={item.alt}
+              description={t(item.description)}
+              image={item.image}
+              isLast={index === navCardItems.length - 1}
+              buttonLink={item.buttonLink}
+            />
+          </div>
         ))}
       </div>
     );

--- a/src/components/common/NavCardList.tsx
+++ b/src/components/common/NavCardList.tsx
@@ -4,7 +4,7 @@ import Pgwp from "@/public/pgwp.png";
 import Sowp from "@/public/sowp.png";
 import WorkPermitExtensions from "@/public/work-permit-extensions.png";
 import { useTranslations } from 'next-intl';
-import { StaticImageData } from "next/image";
+import { StaticImageData } from "next/legacy/image";
 import { forwardRef } from "react";
 import { NavCardItem } from "../../app/work/_components/NavCardItem";
 

--- a/src/components/common/NavCardList.tsx
+++ b/src/components/common/NavCardList.tsx
@@ -3,8 +3,8 @@ import OpenWorkPermit from "@/public/open-work-permit.png";
 import Pgwp from "@/public/pgwp.png";
 import Sowp from "@/public/sowp.png";
 import WorkPermitExtensions from "@/public/work-permit-extensions.png";
-import { useTranslations } from 'next-intl';
-import { StaticImageData } from "next/legacy/image";
+import { useTranslations } from "next-intl";
+import { StaticImageData } from "next/image";
 import { forwardRef } from "react";
 import { NavCardItem } from "../../app/work/_components/NavCardItem";
 
@@ -29,72 +29,71 @@ type navCardItemsType = {
 };
 
 const navCardItems: navCardItemsType[] = [
-    {
-        ref: 'workPermitRef',
-        id: 'work-permit-extensions',
-        title: 'navCard1Title',
-        alt: 'Work Permit Extensions',
-        description: 'navCard1Description',
-        image: WorkPermitExtensions,
-    },
-    {
-        ref: 'openWorkPermitRef',
-        id: 'open-work-permit',
-        title: 'navCard2Title',
-        alt: 'Open Work Permit',
-        description: 'navCard2Description',
-        image: OpenWorkPermit,
-    },
-    {
-        ref: 'pgwpRef',
-        id: 'pgwp',
-        title: 'navCard3Title',
-        alt: 'Post-Graduation Work Permit (PGWP)',
-        description: 'navCard3Description',
-        image: Pgwp,
-    },
-    {
-        ref: 'lmiaRef',
-        id: 'lmia',
-        title: 'navCard4Title',
-        alt: 'Labour Market Impact Assessment (LMIA)',
-        description: 'navCard4Description',
-        image: Lmia,
-    },
-    {
-        ref: 'sowpRef',
-        id: 'sowp',
-        title: 'navCard5Title',
-        alt: 'Spousal/ Common-Law Partner Open Work Permit (SOWP)',
-        description: 'navCard5Description',
-        image: Sowp,
-    },
+  {
+    ref: "workPermitRef",
+    id: "work-permit-extensions",
+    title: "navCard1Title",
+    alt: "Work Permit Extensions",
+    description: "navCard1Description",
+    image: WorkPermitExtensions,
+  },
+  {
+    ref: "openWorkPermitRef",
+    id: "open-work-permit",
+    title: "navCard2Title",
+    alt: "Open Work Permit",
+    description: "navCard2Description",
+    image: OpenWorkPermit,
+  },
+  {
+    ref: "pgwpRef",
+    id: "pgwp",
+    title: "navCard3Title",
+    alt: "Post-Graduation Work Permit (PGWP)",
+    description: "navCard3Description",
+    image: Pgwp,
+  },
+  {
+    ref: "lmiaRef",
+    id: "lmia",
+    title: "navCard4Title",
+    alt: "Labour Market Impact Assessment (LMIA)",
+    description: "navCard4Description",
+    image: Lmia,
+  },
+  {
+    ref: "sowpRef",
+    id: "sowp",
+    title: "navCard5Title",
+    alt: "Spousal/ Common-Law Partner Open Work Permit (SOWP)",
+    description: "navCard5Description",
+    image: Sowp,
+  },
 ];
 
 export const NavCardList = forwardRef<HTMLDivElement, Props>(
   function NavCardList({ refs }: Props, ref) {
-
     const t = useTranslations("Work");
 
     return (
-        <div
-            className='flex flex-col xl:grid xl:grid-cols-3 gap-4 flex-shrink-0'
-            ref={ref}
-        >
-            {navCardItems.map((item, index) => (
-                <NavCardItem
-                    key={item.id}
-                    ref={refs[item.ref as keyof typeof refs]}
-                    id={item.id}
-                    title={t(item.title)}
-                    alt={item.alt}
-                    description={t(item.description)}
-                    image={item.image}
-                    isLast={index === navCardItems.length - 1}
-                    buttonLink={item.buttonLink}
-                />
-            ))}
-        </div>
+      <div
+        className="flex flex-col xl:grid xl:grid-cols-3 gap-4 flex-shrink-0"
+        ref={ref}
+      >
+        {navCardItems.map((item, index) => (
+          <NavCardItem
+            key={item.id}
+            ref={refs[item.ref as keyof typeof refs]}
+            id={item.id}
+            title={t(item.title)}
+            alt={item.alt}
+            description={t(item.description)}
+            image={item.image}
+            isLast={index === navCardItems.length - 1}
+            buttonLink={item.buttonLink}
+          />
+        ))}
+      </div>
     );
   }
 );

--- a/src/components/common/ResponsiveImage.tsx
+++ b/src/components/common/ResponsiveImage.tsx
@@ -1,6 +1,5 @@
 import { cn } from "@/lib/utils";
-import Image, { StaticImageData } from "next/legacy/image";
-
+import Image, { StaticImageData } from "next/image";
 
 type Props = {
   alt: string;
@@ -45,9 +44,10 @@ export const ResponsiveImage = ({
       <Image
         alt={alt}
         src={src}
-        layout={"fill"}
-        objectFit={"cover"}
-        quality={100}
+        fill
+        style={{ objectFit: "cover" }}
+        sizes="auto"
+        quality={50}
         className={cn(imgClassName)}
       />
       {children}

--- a/src/components/common/ResponsiveImage.tsx
+++ b/src/components/common/ResponsiveImage.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import Image, { StaticImageData } from "next/image";
+import Image, { StaticImageData } from "next/legacy/image";
 
 
 type Props = {

--- a/src/components/common/Testimonial.tsx
+++ b/src/components/common/Testimonial.tsx
@@ -4,9 +4,9 @@ import { cn } from "@/lib/utils";
 import googleReview from "@/public/googleReview.png";
 import { TestimonialsType } from "@/types/TestimonialsType";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
 import Link from "next/link";
 import { Card } from "../ui/card";
+import { ResponsiveImage } from "./ResponsiveImage";
 import { Caption } from "./text/Caption";
 import { Heading } from "./text/Heading";
 import { HeavyBody } from "./text/HeavyBody";
@@ -37,30 +37,22 @@ export const Testimonial = ({ testimonials, className }: Props) => {
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
           {testimonials.map((testimonial) => (
             <Card key={testimonial.name}>
-              <div className="relative w-full h-[236px] rounded-t-lg overflow-hidden">
-                <Image
-                  src={testimonial.image}
-                  alt={testimonial.name}
-                  layout="fill"
-                  objectFit="cover"
-                  className="rounded-t-lg"
-                />
-              </div>
+              <ResponsiveImage
+                alt={testimonial.name}
+                src={testimonial.image}
+                divClassName="w-full h-[236px] rounded-t-lg overflow-hidden"
+              />
+
               <div className="flex flex-col p-4 gap-4">
-                <div className="">
-                  <div className="flex justify-between">
-                    <HeavySubHeader>{testimonial.name}</HeavySubHeader>
-                    <div className="flex items-center">
-                      <Image
-                        src={testimonial.countryImage}
-                        alt={testimonial.country}
-                        width={22}
-                        height={16}
-                      />
-                    </div>
-                  </div>
-                  <Caption>{testimonial.status}</Caption>
+                <div className="flex justify-between items-center">
+                  <HeavySubHeader>{testimonial.name}</HeavySubHeader>
+                  <ResponsiveImage
+                    src={testimonial.countryImage}
+                    alt={testimonial.country}
+                    divClassName="w-[22px] h-[16px]"
+                  />
                 </div>
+                <Caption>{testimonial.status}</Caption>
                 <div className="flex">
                   {[1, 2, 3, 4, 5].map((star) => (
                     <svg
@@ -82,12 +74,10 @@ export const Testimonial = ({ testimonials, className }: Props) => {
           ))}
         </div>
         <div className="flex flex-col items-center pt-4">
-          <Image
-            className="flex justify-center"
-            src={googleReview}
+          <ResponsiveImage
             alt="Google Reviews"
-            width={150}
-            height={100}
+            src={googleReview}
+            divClassName="w-[150px] h-[85px]"
           />
           <Paragraph className="text-gray-600 py-4">
             {t("googleReviews")}

--- a/src/components/common/Testimonial.tsx
+++ b/src/components/common/Testimonial.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import googleReview from "@/public/googleReview.png";
 import { TestimonialsType } from "@/types/TestimonialsType";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 import Link from "next/link";
 import { Card } from "../ui/card";
 import { Caption } from "./text/Caption";

--- a/src/components/common/Testimonial.tsx
+++ b/src/components/common/Testimonial.tsx
@@ -87,7 +87,7 @@ export const Testimonial = ({ testimonials, className }: Props) => {
             src={googleReview}
             alt="Google Reviews"
             width={150}
-            height={50}
+            height={100}
           />
           <Paragraph className="text-gray-600 py-4">
             {t("googleReviews")}

--- a/src/components/common/TestimonialMobile.tsx
+++ b/src/components/common/TestimonialMobile.tsx
@@ -11,10 +11,10 @@ import { cn } from "@/lib/utils";
 import googleReview from "@/public/googleReview.png";
 import { TestimonialsType } from "@/types/TestimonialsType";
 import { useTranslations } from "next-intl";
-import Image from "next/legacy/image";
 import Link from "next/link";
 import * as React from "react";
 import { Button } from "../ui/UpImmigrationButton";
+import { ResponsiveImage } from "./ResponsiveImage";
 import { SectionContainer } from "./SectionContainer";
 import { Caption } from "./text/Caption";
 import { Heading } from "./text/Heading";
@@ -59,12 +59,10 @@ export default function TestimonialMobile({ testimonials, className }: Props) {
     <SectionContainer className={cn("lg:hidden", className)}>
       <Heading>{t("testimonialsTitle")}</Heading>
       <div className="flex justify-between">
-        <Image
-          className="flex justify-center"
-          src={googleReview}
+        <ResponsiveImage
           alt="Google Reviews"
-          width={150}
-          height={100}
+          src={googleReview}
+          divClassName="w-[150px] h-[85px] "
         />
         <h1 className="text-5xl flex items-center text-secondary-blue font-bold">
           5.0
@@ -77,23 +75,19 @@ export default function TestimonialMobile({ testimonials, className }: Props) {
               <CarouselItem key={index}>
                 <Card className="border-none shadow-testimonials-card rounded-[20px] overflow-hidden">
                   <div className="flex gap-3">
-                    <div className="relative w-[50%] rounded-l-lg">
-                      <Image
-                        src={testimonial.imageMobile}
-                        alt={`${testimonial.name}'s testimonial`}
-                        layout="fill"
-                        objectFit="cover"
-                        className="rounded-l-lg"
-                      />
-                    </div>
+                    <ResponsiveImage
+                      src={testimonial.imageMobile}
+                      alt={`${testimonial.name}'s testimonial`}
+                      divClassName="w-[50%] rounded-l-lg"
+                    />
+
                     <div className="flex w-[50%] flex-col justify-center py-4 pr-4">
                       <div className="flex justify-between items-center">
                         <HeavySubHeader>{testimonial.name}</HeavySubHeader>
-                        <Image
-                          src={testimonial.countryImage}
+                        <ResponsiveImage
                           alt={testimonial.country}
-                          height={16}
-                          width={22}
+                          src={testimonial.countryImage}
+                          divClassName="h-[16px] w-[22px]"
                         />
                       </div>
                       <Caption>{testimonial.status}</Caption>

--- a/src/components/common/TestimonialMobile.tsx
+++ b/src/components/common/TestimonialMobile.tsx
@@ -73,7 +73,7 @@ export default function TestimonialMobile({ testimonials, className }: Props) {
           <CarouselContent>
             {testimonials.map((testimonial, index) => (
               <CarouselItem key={index}>
-                <Card className="border-none shadow-testimonials-card rounded-[20px] overflow-hidden">
+                <Card className="my-1 mx-1 border-none shadow-testimonials-card rounded-[20px] overflow-hidden">
                   <div className="flex gap-3">
                     <ResponsiveImage
                       src={testimonial.imageMobile}
@@ -101,7 +101,7 @@ export default function TestimonialMobile({ testimonials, className }: Props) {
             ))}
           </CarouselContent>
         </Carousel>
-        <div className="flex justify-center gap-2 mt-4">
+        <div className="flex justify-center gap-2 mt-2">
           {Array.from({ length: count }).map((_, index) => (
             <button
               key={index}

--- a/src/components/common/TestimonialMobile.tsx
+++ b/src/components/common/TestimonialMobile.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 import googleReview from "@/public/googleReview.png";
 import { TestimonialsType } from "@/types/TestimonialsType";
 import { useTranslations } from "next-intl";
-import Image from "next/image";
+import Image from "next/legacy/image";
 import Link from "next/link";
 import * as React from "react";
 import { Button } from "../ui/UpImmigrationButton";

--- a/src/components/common/TestimonialMobile.tsx
+++ b/src/components/common/TestimonialMobile.tsx
@@ -64,7 +64,7 @@ export default function TestimonialMobile({ testimonials, className }: Props) {
           src={googleReview}
           alt="Google Reviews"
           width={150}
-          height={50}
+          height={100}
         />
         <h1 className="text-5xl flex items-center text-secondary-blue font-bold">
           5.0

--- a/src/components/common/faq.tsx
+++ b/src/components/common/faq.tsx
@@ -45,9 +45,9 @@ const FAQ = ({ data, title, bgColor, className }: Props) => {
         <Accordion type="multiple">
           {data.map((item, index) => (
             <AccordionItem key={item.id} value={item.id}>
-              <AccordionTrigger className="items-start text-start">{`${
-                index + 1
-              }. ${item.question}`}</AccordionTrigger>
+              <AccordionTrigger className="text-start">{`${index + 1}. ${
+                item.question
+              }`}</AccordionTrigger>
               <AccordionContent>{item.answer}</AccordionContent>
             </AccordionItem>
           ))}

--- a/src/components/common/faq.tsx
+++ b/src/components/common/faq.tsx
@@ -45,9 +45,9 @@ const FAQ = ({ data, title, bgColor, className }: Props) => {
         <Accordion type="multiple">
           {data.map((item, index) => (
             <AccordionItem key={item.id} value={item.id}>
-              <AccordionTrigger>{`${index + 1}. ${
-                item.question
-              }`}</AccordionTrigger>
+              <AccordionTrigger className="items-start text-start">{`${
+                index + 1
+              }. ${item.question}`}</AccordionTrigger>
               <AccordionContent>{item.answer}</AccordionContent>
             </AccordionItem>
           ))}

--- a/src/components/common/text/HeavySubHeader.tsx
+++ b/src/components/common/text/HeavySubHeader.tsx
@@ -23,7 +23,7 @@ export const HeavySubHeader = ({
   return (
     <p
       className={cn(
-        "text-text-heavy-sub-header-mobile xl:text-text-heavy-sub-header h-16",
+        "text-text-heavy-sub-header-mobile xl:text-text-heavy-sub-header",
         className
       )}
     >

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,9 +1,8 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
@@ -16,9 +15,9 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Textarea.displayName = "Textarea"
+);
+Textarea.displayName = "Textarea";
 
-export { Textarea }
+export { Textarea };

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -3,10 +3,7 @@
 // Inspired by react-hot-toast library
 import * as React from "react";
 
-import type {
-  ToastActionElement,
-  ToastProps,
-} from "@/components/ui/toast";
+import type { ToastActionElement, ToastProps } from "@/components/ui/toast";
 
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000000;
@@ -18,6 +15,7 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const actionTypes = {
   ADD_TOAST: "ADD_TOAST",
   UPDATE_TOAST: "UPDATE_TOAST",

--- a/src/types/TestimonialsType.ts
+++ b/src/types/TestimonialsType.ts
@@ -1,4 +1,4 @@
-import { StaticImageData } from "next/image";
+import { StaticImageData } from "next/legacy/image";
 
 export type TestimonialsType = {
   name: string;

--- a/src/types/TestimonialsType.ts
+++ b/src/types/TestimonialsType.ts
@@ -1,4 +1,4 @@
-import { StaticImageData } from "next/legacy/image";
+import { StaticImageData } from "next/image";
 
 export type TestimonialsType = {
   name: string;

--- a/src/types/studyCardType.ts
+++ b/src/types/studyCardType.ts
@@ -1,4 +1,4 @@
-import { StaticImageData } from "next/legacy/image";
+import { StaticImageData } from "next/image";
 
 export type StudyCardType = {
   title: string;

--- a/src/types/studyCardType.ts
+++ b/src/types/studyCardType.ts
@@ -1,4 +1,4 @@
-import { StaticImageData } from "next/image";
+import { StaticImageData } from "next/legacy/image";
 
 export type StudyCardType = {
   title: string;


### PR DESCRIPTION
- Fix spelling mistakes;
- Install Sharp (Node.js library for image processing) for image optimization;
- Remove Unused workComponents variable from navigation menu;
- Install and run @next/codemod to convert next image to legacy image;
- Fix Header Height that broke after running codemod;
- Comment out the unused variables from LocaleSwitcher;
- Disabling ESlint to actionTypes line 19 on src\hooks\use-toast.ts;
- Deleting empty pages that was giving the compiler unnecessary work and causing compiling errors;
- Change the objects to function on data arrays related to the translation;
- Change the component path from BookConsultationButton to UpImmigrationButton on DiscoverOptionsButton Component;
- Fixing height of PNP page images;
- Fixing height of Express Entry page images;
- Fixing height of all Immigration pages images;
- Converting the images back to next/image;
- Fixing EEPrograms and PNPrograms images turning the borders rounded;
- Fixing Immigration Card Component;
- Fixing Work Page Card Component;
- Changing the Portuguese title of Spousal/Common-law;
- Fixing Testimonials Card Mobile;
- Fixing TestimonialsType and StudyCardType;
